### PR TITLE
Remove unnecessary MFC includes

### DIFF
--- a/MiB64.rc
+++ b/MiB64.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/MiB64_Cheat.rc
+++ b/MiB64_Cheat.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/main2.cpp
+++ b/main2.cpp
@@ -1,5 +1,4 @@
 #include <windows.h>
-#include <ATLBASE.H>
 #include <EXDISP.h>
 #include <CommCtrl.h>
 #include "main.h"


### PR DESCRIPTION
Not sure why these were there. They aren't used for anything, but they add a HUGE multi-GB dependency that developers need to install in MSVC to compile three lines.

WTF?